### PR TITLE
add getIncomesByCategory function

### DIFF
--- a/src/lib/incomes.test.ts
+++ b/src/lib/incomes.test.ts
@@ -73,7 +73,7 @@ describe('incomes', () => {
     expect(index).toEqual('year')
   })
 
-  test.skip('should get incomes by category formatted', async () => {
+  test('should get incomes by category formatted', async () => {
     const databaseMock = vi.spyOn(database, 'get')
     const mockData = [{
       MODIFICACION: 0,
@@ -107,7 +107,7 @@ describe('incomes', () => {
       ID_ARTICULO: '1-1'
     }, {
       MODIFICACION: 0,
-      EJERCICIO: '2002',
+      EJERCICIO: '2001',
       ID_CONCEPTO: '1-1-0',
       ID_SUBCONCEPTO: '1-1-0-01',
       DESC_CONCEPTO: 'Impuesto General Sobre Sucesiones Y Donaciones',

--- a/src/lib/incomes.ts
+++ b/src/lib/incomes.ts
@@ -62,11 +62,32 @@ export async function getIncomes (): Promise<ChartData> {
 }
 
 export async function getIncomesByCategory (): Promise<ChartData> {
-  // TODO: Implement this function
+  const reponse = await database.get<IncomeDTO>(config.incomes.fileName)
+  const incomes = reponse.map(mapDtoToIncome)
+
+  const years = Array.from(new Set(incomes.map(d => d.year)))
+  const categories = Array.from(new Set(incomes.map(d => d.category)))
+
+  const data = years.map(year => {
+    const amounts = categories.map(category => {
+      const categoryAmount = incomes.reduce((acc, d) => {
+        if (d.year === year && d.category === category) {
+          return acc + d.amount
+        }
+        return acc
+      }, 0)
+      return categoryAmount
+    })
+
+    return {
+      year,
+      ...Object.fromEntries(categories.map((c, i) => [c, amounts[i]]).filter(([, amount]) => amount !== 0))
+    }
+  })
 
   return {
     index: 'year',
-    categories: [],
-    data: []
+    categories,
+    data
   }
 }


### PR DESCRIPTION
In this PR I added the functionality to getIncomes grouped by category and year from issue #37 

I also did a small fix on the tests, where one of the years in the test input data was wrong and did not match the expected data.